### PR TITLE
A few fixes to the N1MM UDP ContactInfo message

### DIFF
--- a/fdlogger/__main__.py
+++ b/fdlogger/__main__.py
@@ -1660,8 +1660,13 @@ class MainWindow(QtWidgets.QMainWindow):
                 logger.warning("%s", err)
 
         if self.preference.get("send_n1mm_packets"):
-            self.n1mm.contact_info["rxfreq"] = str(self.oldfreq)[:-1]
-            self.n1mm.contact_info["txfreq"] = str(self.oldfreq)[:-1]
+            if self.oldfreq == 0:
+               self.n1mm.contact_info["rxfreq"] = str(self.fakefreq(self.band, self.mode))
+               self.n1mm.contact_info["txfreq"] = str(self.fakefreq(self.band, self.mode))
+            else:
+                self.n1mm.contact_info["rxfreq"] = str(self.oldfreq)[:-1]
+                self.n1mm.contact_info["txfreq"] = str(self.oldfreq)[:-1]
+                
             self.n1mm.contact_info["mode"] = self.oldmode
             if self.oldmode in ("CW", "DG"):
                 self.n1mm.contact_info["points"] = "2"

--- a/fdlogger/__main__.py
+++ b/fdlogger/__main__.py
@@ -2667,8 +2667,6 @@ else:
     print("debugging off")
     logger.setLevel(logging.WARNING)
 
-
-
 app = QtWidgets.QApplication(sys.argv)
 app.setStyle("Fusion")
 working_path = os.path.dirname(__loader__.get_filename())

--- a/fdlogger/__main__.py
+++ b/fdlogger/__main__.py
@@ -1066,6 +1066,7 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             logger.info("cat_control %s", self.cat_control)
             self.radio_icon.setPixmap(QtGui.QPixmap(self.radio_grey))
+            self.oldmode = self.mode # Set so the UDP packet sends mode when no radio connected - NY4I
 
     def flash(self):
         """Flash the screen"""
@@ -1666,7 +1667,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.n1mm.contact_info["points"] = "2"
             else:
                 self.n1mm.contact_info["points"] = "1"
-            self.n1mm.contact_info["band"] = self.band
+            self.n1mm.contact_info["band"] = self.n1mm.bandToUDPBand[self.band]
             self.n1mm.contact_info["mycall"] = self.preference.get("mycall")
             self.n1mm.contact_info["IsRunQSO"] = str(self.run_state)
             self.n1mm.contact_info["timestamp"] = datetime.now(dt.UTC).strftime(
@@ -2665,6 +2666,8 @@ if Path("./debug").exists():
 else:
     print("debugging off")
     logger.setLevel(logging.WARNING)
+
+
 
 app = QtWidgets.QApplication(sys.argv)
 app.setStyle("Fusion")

--- a/fdlogger/lib/n1mm.py
+++ b/fdlogger/lib/n1mm.py
@@ -99,6 +99,20 @@ class N1MM:
         "StationName": "",
         "ID": "",
     }
+    
+    bandToUDPBand = {
+       "160" : "1.8",
+       "80"  : "3.5",
+       "40"  : "7",
+       "20"  : "14",
+       "15"  : "21",
+       "10"  : "28",
+       "6"   : "50",
+       "2"   : "144",
+       "222" : "222",
+       "432" : "420",
+       "SAT" : "144", # The fakefreqs are 2m so I picked 2m for SAT - NY4I
+    }
 
     def __init__(
         self,


### PR DESCRIPTION
The format of the band field in the ContactInfo UDP message sent to the Dashboard and n1mm_view was incorrect. 

Also, if the radio was not connected, the mode sent was incorrect.

Lastly if the CAT connection was set to rigctld, but no radio was running (as in rigctld was not running), the rxfreq and txfreq sent was set to 0. The code will not use the fakefreq function if those frequencies are zero.

Note I suspect the same issue with the band info exists in your NotN1MM logger as well as Winter Field Day. I did not propagate this change to those repos.

This PR would close issue #36 .

Note the code I added to check if the frequency is zero could be moved into the n1mm library as an edit check on the way out. That would make the change more modular but would contribute to post-check edit processing which may not be desirable.



