### PR TITLE
Fix: Send FT8 contacts to server immediately

### DIFF
--- a/fdlogger/__main__.py
+++ b/fdlogger/__main__.py
@@ -807,6 +807,32 @@ class MainWindow(QtWidgets.QMainWindow):
                 unique_id,
             )
             self.db.log_ft8_contact(contact)
+            if self.connect_to_server:
+                stale = datetime.now() + timedelta(seconds=30)
+                server_contact = {
+                    "cmd": "POST",
+                    "hiscall": call,
+                    "class": hisclass,
+                    "section": hissect,
+                    "mode": "DI",
+                    "band": band,
+                    "frequency": freq,
+                    "date_and_time": the_dt,
+                    "power": int(self.preference["power"]),
+                    "grid": grid,
+                    "opname": name,
+                    "station": self.preference["mycall"],
+                    "unique_id": unique_id,
+                    "expire": stale.isoformat(),
+                }
+                self.server_commands.append(server_contact)
+                bytesToSend = bytes(dumps(server_contact), encoding="ascii")
+                try:
+                    self.server_udp.sendto(
+                        bytesToSend, (self.multicast_group, int(self.multicast_port))
+                    )
+                except OSError as err:
+                    logger.warning("%s", err)
             self.sections()
             self.stats()
             self.updatemarker()


### PR DESCRIPTION
- FT8 contacts are now sent to fdserver via UDP multicast immediately when logged, instead of waiting for next manual contact or log generation
- Maintains consistency with CW/Phone contact server communication
- Resolves issue where FT8 contacts were only pushed during batch operations

Fixes issue where FT8 contacts logged via WSJT-X integration were not immediately visible to other operators in group logging scenarios.

#Pull Request
